### PR TITLE
refactor(storage): generalize move object feature to all types of buckets

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -14,7 +14,6 @@
 
 using Google.Cloud.ClientTesting;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -35,7 +34,7 @@ public class MoveObjectTest
     public MoveObjectTest(StorageFixture fixture)
     {
         _fixture = fixture;
-        _bucket = _fixture.HnsBucket;
+        _bucket = _fixture.InitiallyEmptyBucket;
         _originName = IdGenerator.FromGuid();
         _destinationName = IdGenerator.FromGuid();
         _contentType = "application/octet-stream";

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
 
         /// <summary>
         /// Name of a bucket which already exists, but has no canned data. Mostly used
-        /// for creating objects.
+        /// for creating and moving objects.
         /// </summary>
         public string InitiallyEmptyBucket => BucketPrefix + "-empty";
 
@@ -60,11 +60,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         /// for 24 hours.
         /// </summary>
         public string SoftDeleteBucket => BucketPrefix + "-soft-delete";
-
-        /// <summary>
-        /// Name of a bucket with hierarchical namespace enabled
-        /// </summary>
-        public string HnsBucket => BucketPrefix + "-hns";
 
         /// <summary>
         /// A small amount of content. Do not mutate the array.
@@ -172,7 +167,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             CreateBucket(LabelsTestBucket, multiVersion: false);
             CreateBucket(InitiallyEmptyBucket, multiVersion: false);
             CreateBucket(SoftDeleteBucket, multiVersion: false, softDelete: true);
-            CreateBucket(HnsBucket, multiVersion: false, hnsEnabled: true);
 
             RequesterPaysClient = CreateRequesterPaysClient();
             if (RequesterPaysClient != null)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -22,7 +22,7 @@ namespace Google.Cloud.Storage.V1;
 public abstract partial class StorageClient
 {
     /// <summary>
-    /// Moves an object within a bucket with hierarchical namespace enabled. This method uses the
+    /// Moves an object within a bucket. This method uses the
     /// <c>moveObject</c> underlying API operation for more flexibility and reliability.
     /// </summary>
     /// <param name="sourceBucket">Name of the bucket containing the object to move. Must not be null.</param>
@@ -41,7 +41,7 @@ public abstract partial class StorageClient
     }
 
     /// <summary>
-    /// Moves an object within a bucket with hierarchical namespace enabled. This method uses the
+    /// Moves an object within a bucket. This method uses the
     /// <c>moveObject</c> underlying API operation for more flexibility and reliability.
     /// </summary>
     /// <param name="sourceBucket">Name of the bucket containing the object to move. Must not be null.</param>


### PR DESCRIPTION
This PR contains code changes to make move object feature generalized for all types of buckets earlier it was limited to hns bucket only