### PR TITLE
feat(Storage): Add filter to ListObjectOptions and integration tests for object context

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/CopyObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/CopyObjectTest.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Storage.v1.Data;
 using Google.Cloud.ClientTesting;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -119,6 +121,37 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                 new CopyObjectOptions { ExtraMetadata = new Object { ContentType = "text/html" } });
             Object fetched = _fixture.Client.GetObject(_fixture.SingleVersionBucket, destName);
             Assert.Equal("text/html", fetched.ContentType);
+        }
+
+        [Fact]
+        public void CopyObjectWithObjectContexts()
+        {
+            string contextKey = "A\u00F1\u03A9\U0001F680";
+            string contextValue = "Ab\u00F1\u03A9\U0001F680";
+            var custom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                  { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+            };
+
+            var destination = new Object
+            {
+                Bucket = _fixture.SingleVersionBucket,
+                Name = IdGenerator.FromGuid(),
+                ContentType = "test/type",
+                ContentDisposition = "attachment",
+                Metadata = new Dictionary<string, string> { { "x", "y" } },
+                Contexts = new Object.ContextsData { Custom = custom }
+            };
+            var source = GenerateData(100);
+            var result = _fixture.Client.UploadObject(destination, source);
+            _fixture.Client.CopyObject(
+                _fixture.SingleVersionBucket, destination.Name,
+                _fixture.MultiVersionBucket, destination.Name);
+            Object fetched = _fixture.Client.GetObject(_fixture.MultiVersionBucket, destination.Name);
+            Assert.Equal(result.Contexts.Custom.Count, fetched.Contexts.Custom.Count);
+            var fetchedEntry = Assert.Single(fetched.Contexts.Custom);
+            Assert.Equal(contextKey, fetchedEntry.Key);
+            Assert.Equal(contextValue, fetchedEntry.Value.Value);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/GetObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/GetObjectTest.cs
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Storage.v1.Data;
 using Google.Cloud.ClientTesting;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
@@ -86,6 +90,38 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(uploaded.Name, softDeleted.Name);
             Assert.Equal((ulong) _fixture.SmallContent.Length, softDeleted.Size);
             Assert.NotNull(softDeleted.SoftDeleteTimeDateTimeOffset);
+        }
+
+        [Fact]
+        public void GetObjectContexts()
+        {
+            string contextKey = "A\u00F1\u03A9\U0001F680";
+            string contextValue = "Ab\u00F1\u03A9\U0001F680";
+            var custom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                  { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+            };
+
+            var destination = new Object
+            {
+                Bucket = _fixture.MultiVersionBucket,
+                Name = IdGenerator.FromGuid(),
+                ContentType = "test/type",
+                ContentDisposition = "attachment",
+                Metadata = new Dictionary<string, string> { { "x", "y" } },
+                Contexts = new Object.ContextsData { Custom = custom }
+            };
+            var source = GenerateData(100);
+            var result = _fixture.Client.UploadObject(destination, source);
+
+
+            var obj = _fixture.Client.GetObject(_fixture.MultiVersionBucket, destination.Name);
+            Assert.Equal(_fixture.MultiVersionBucket, obj.Bucket);
+            Assert.NotNull(obj.Contexts);
+            Assert.Equal(obj.Contexts.Custom.Count, result.Contexts.Custom.Count);
+            var resultEntry = Assert.Single(obj.Contexts.Custom);
+            Assert.Equal(contextKey, resultEntry.Key);
+            Assert.Equal(contextValue, resultEntry.Value.Value);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.ClientTesting;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
@@ -119,6 +123,34 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                 Assert.Null(obj.ContentEncoding);
                 Assert.Null(obj.ContentDisposition);
             }
+        }
+
+        [Fact]
+        public void ListObjectsMatchingContextKeyValuePair()
+        {
+            string contextKey = "A\u00F1\u03A9\U0001F680";
+            string contextValue = "Ab\u00F1\u03A9\U0001F680";
+            var custom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+
+            };
+            var destination = new Object
+            {
+                Bucket = _fixture.ReadBucket,
+                Name = IdGenerator.FromGuid(),
+                Contexts = new Object.ContextsData { Custom = custom }
+            };
+
+            var source = GenerateData(100);
+            _fixture.Client.UploadObject(destination, source);
+            string filter = $@"contexts.""{contextKey}""=""{contextValue}""";
+            var options = new ListObjectsOptions { Filter = filter };
+            var objects = _fixture.Client.ListObjects(_fixture.ReadBucket, options: options).ToList();
+            var obj = Assert.Single(objects);
+            var fetchedContext = Assert.Single(obj.Contexts.Custom);
+            Assert.Equal(contextKey, fetchedContext.Key);
+            Assert.Equal(contextValue, fetchedContext.Value.Value);
         }
 
         private async Task AssertObjects(string prefix, ListObjectsOptions options, params string[] expectedNames)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/PatchObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/PatchObjectTest.cs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Storage.v1.Data;
 using Google.Cloud.ClientTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xunit;
+using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
@@ -49,6 +53,36 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             var client = _fixture.Client;
             Assert.Throws<ArgumentException>(() => client.PatchObject(new Object { Bucket = _fixture.SingleVersionBucket }));
             Assert.Throws<ArgumentException>(() => client.PatchObject(new Object { Name = IdGenerator.FromGuid() }));
+        }
+
+        [Fact]
+        public void ClearAllObjectContexts()
+        {
+            var client = _fixture.Client;
+            var custom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                  { "A\u00F1\u03A9\U0001F680", new ObjectCustomContextPayload { Value = "Ab\u00F1\u03A9\U0001F680" } }
+            };
+
+            var destination = new Object
+            {
+                Bucket = _fixture.SingleVersionBucket,
+                Name = IdGenerator.FromGuid(),
+                ContentType = "test/type",
+                ContentDisposition = "attachment",
+                Metadata = new Dictionary<string, string> { { "x", "y" } },
+                Contexts = new Object.ContextsData { Custom = custom }
+            };
+            var source = GenerateData(100);
+            _fixture.Client.UploadObject(destination, source);
+
+            var modifiedCustom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+            };
+
+            Object obj = new Object { Name = destination.Name, Bucket = destination.Bucket, ContentType = "text/plain", Contexts = new Object.ContextsData { Custom = modifiedCustom } };
+            var updated = client.PatchObject(obj);
+            Assert.Null(updated.Contexts);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UpdateObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UpdateObjectTest.cs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Storage.v1.Data;
 using Google.Cloud.ClientTesting;
 using System.Collections.Generic;
 using System.IO;
 using Xunit;
+using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
@@ -38,6 +40,51 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             obj.Metadata = new Dictionary<string, string> { { "key", "value" } };
             var updated = client.UpdateObject(obj);
             Assert.Equal("value", updated.Metadata["key"]);
+        }
+
+        [Fact]
+        public void UpdateObjectWithObjectContexts()
+        {
+            var client = _fixture.Client;
+            var source = GenerateData(100);
+            string contextKey = "A\u00F1\u03A9\U0001F680";
+            string contextValue = "Ab\u00F1\u03A9\U0001F680";
+            var custom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                  { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+            };
+
+            var destination = new Object
+            {
+                Bucket = _fixture.MultiVersionBucket,
+                Name = IdGenerator.FromGuid(),
+                ContentType = "test/type",
+                ContentDisposition = "attachment",
+                Metadata = new Dictionary<string, string> { { "x", "y" } },
+                Contexts = new Object.ContextsData { Custom = custom }
+            };
+
+            var result = client.UploadObject(destination, source);
+            string modifiedContextValue = "AAb\u00F1\u03A9\U0001F680";
+            var modifiedCustom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                  { contextKey, new ObjectCustomContextPayload { Value = modifiedContextValue } }
+
+            };
+
+            var modifiedDestination = new Object
+            {
+                Bucket = _fixture.MultiVersionBucket,
+                Name = destination.Name,
+                Contexts = new Object.ContextsData { Custom = modifiedCustom }
+            };
+            var updated = client.UpdateObject(modifiedDestination);
+            Assert.NotNull(updated.Contexts.Custom);
+            Assert.Equal(modifiedCustom.Count, updated.Contexts.Custom.Count);
+            var resultEntry = Assert.Single(result.Contexts.Custom);
+            var updatedEntry = Assert.Single(updated.Contexts.Custom);
+            Assert.Equal(modifiedContextValue, updatedEntry.Value.Value);
+            Assert.NotEqual(updatedEntry.Value.UpdateTimeRaw, resultEntry.Value.UpdateTimeRaw);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UploadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UploadObjectTest.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -88,6 +89,33 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(destination.ContentType, result.ContentType);
             Assert.Equal(destination.ContentDisposition, result.ContentDisposition);
             Assert.Equal(destination.Metadata, result.Metadata);
+            ValidateData(_fixture.MultiVersionBucket, destination.Name, source);
+        }
+
+        [Fact]
+        public void UploadObjectWithObjectContexts()
+        {
+            string contextKey = "A\u00F1\u03A9\U0001F680";
+            string contextValue = "Ab\u00F1\u03A9\U0001F680";
+            var custom = new Dictionary<string, ObjectCustomContextPayload>
+            {
+                { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+            };
+            var destination = new Object
+            {
+                Bucket = _fixture.MultiVersionBucket,
+                Name = IdGenerator.FromGuid(),
+                Contexts = new Object.ContextsData { Custom = custom }
+            };
+            var source = GenerateData(100);
+            var result = _fixture.Client.UploadObject(destination, source);
+            Assert.Equal(destination.Name, result.Name);
+            Assert.Equal(destination.Bucket, result.Bucket);
+            var resultEntry = Assert.Single(result.Contexts.Custom);
+            Assert.Equal(contextKey, resultEntry.Key);
+            Assert.Equal(contextValue, resultEntry.Value.Value);
+            Assert.NotNull(resultEntry.Value.CreateTimeRaw);
+            Assert.NotNull(resultEntry.Value.UpdateTimeRaw);
             ValidateData(_fixture.MultiVersionBucket, destination.Name, source);
         }
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListObjectsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListObjectsOptionsTest.cs
@@ -38,6 +38,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.StartOffset);
             Assert.Null(request.EndOffset);
             Assert.Null(request.MatchGlob);
+            Assert.Null(request.Filter);
         }
 
         [Fact]
@@ -58,7 +59,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 Fields = "items(name),nextPageToken",
                 StartOffset = "start",
                 EndOffset = "end",
-                MatchGlob = "a/*.txt"
+                MatchGlob = "a/*.txt",
+                Filter = "contexts.\"key\":*\""
             };
             options.ModifyRequest(request);
             Assert.Equal(10, request.MaxResults);
@@ -74,6 +76,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal("start", request.StartOffset);
             Assert.Equal("end", request.EndOffset);
             Assert.Equal("a/*.txt", request.MatchGlob);
+            Assert.Equal("contexts.\"key\":*\"", request.Filter);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
@@ -107,6 +107,12 @@ namespace Google.Cloud.Storage.V1
         public string EndOffset { get; set; }
 
         /// <summary>
+        /// If set, filters results to include only objects to which the specified context is attached.
+        /// If delimiter is set, the returned prefixes are exempt from this filter.
+        /// </summary>
+        public string Filter { get; set; }
+
+        /// <summary>
         /// Options to pass custom retry configuration for each API request.
         /// </summary>
         public RetryOptions RetryOptions { get; set; }
@@ -168,6 +174,10 @@ namespace Google.Cloud.Storage.V1
             if (MatchGlob != null)
             {
                 request.MatchGlob = MatchGlob;
+            }
+            if (Filter != null)
+            {
+                request.Filter = Filter;
             }
         }
     }


### PR DESCRIPTION
This PR introduces the ability to filter ListObjects results with the introduction of `Filter` property in `ListObjectOptions` and adds comprehensive integration tests for the `Object Context` feature. Please see [b/434726579](http:/b/434726579)